### PR TITLE
Added Executions to tracked Events

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The event log file is written as [csv RFC4180](https://tools.ietf.org/html/rfc41
     - **IDE actions**: event type = `Action`, event data = `[action id]` (e.g. `Action,EditorUp`);
                        or event type = `VcsAction`, event data = `[Push|Update|Commit]`;
                        or event type = `CompilationFinished`, event data = `[amount of errors during compilation]`.
+    - **Executions**: event type = `Execution`, event data = `[Run:Debug:Coverage]:[Run Configuration name]:[full commandline instruction]`.
     - **IDE polling events**: event type = `IdeState`, event data = `[Active|Inactive|NoProject]`,
       where `Inactive` means IDE doesn't have focus, `NoProject` mean all projects are closed.
     - **keyboard events**: event type = `KeyEvent`, event data = `[keyChar]:[keyCode]:[modifiers]`

--- a/src/main/activitytracker/TrackerEvent.kt
+++ b/src/main/activitytracker/TrackerEvent.kt
@@ -28,7 +28,8 @@ data class TrackerEvent(
         Action,
         VcsAction,
         CompilationFinished,
-        Duration
+        Duration,
+        Execution
     }
 
     companion object {


### PR DESCRIPTION
While Run Actions are already tracked, the executed IntelliJ Run Configuration (and the full commandline instruction) are not logged yet.