### PR TITLE
Add the KEY_RELEASED event to tracked Events

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The event log file is written as [csv RFC4180](https://tools.ietf.org/html/rfc41
     - **Executions**: event type = `Execution`, event data = `[Run|Debug|Coverage]:[Run configuration name]:[full commandline instruction]`.
     - **IDE polling events**: event type = `IdeState`, event data = `[Active|Inactive|NoProject]`,
       where `Inactive` means IDE doesn't have focus, `NoProject` mean all projects are closed.
-    - **keyboard events**: event type = `KeyEvent`, event data = `[keyChar]:[keyCode]:[modifiers]`
+    - **keyboard events**: event type = `KeyEvent`, event data = `[eventId]:[keyChar]:[keyCode]:[modifiers]`
       (see [AWT KeyEvent](https://docs.oracle.com/javase/7/docs/api/java/awt/event/KeyEvent.html)).
     - **mouse events**: event type = `MouseEvent`, event data can be
         - `click:[button]:[clickCount]:[modifiers]`
@@ -87,10 +87,10 @@ The event log file is written as [csv RFC4180](https://tools.ietf.org/html/rfc41
 ```
 2015-12-31T17:42:30.171Z,dima,IdeState,Active,activity-tracker,Editor,/path/to/jdk/src.zip!/java/awt/AWTEvent.java,AWTEvent::isConsumed,450,8,
 2015-12-31T17:42:30.35Z,dima,Action,EditorLineEnd,activity-tracker,Editor,/path/to/jdk/src.zip!/java/awt/AWTEvent.java,AWTEvent::isConsumed,450,8,
-2015-12-31T17:42:30.351Z,dima,KeyEvent,97:79:8,activity-tracker,Editor,/path/to/jdk/src.zip!/java/awt/AWTEvent.java,AWTEvent::isConsumed,450,24,
+2015-12-31T17:42:30.351Z,dima,KeyEvent,401:97:79:8,activity-tracker,Editor,/path/to/jdk/src.zip!/java/awt/AWTEvent.java,AWTEvent::isConsumed,450,24,
 2015-12-31T17:42:30.566Z,dima,Action,EditorLineStart,activity-tracker,Editor,/path/to/jdk/src.zip!/java/awt/AWTEvent.java,AWTEvent::isConsumed,450,24,
-2015-12-31T17:42:30.568Z,dima,KeyEvent,97:85:8,activity-tracker,Editor,/path/to/jdk/src.zip!/java/awt/AWTEvent.java,AWTEvent::isConsumed,450,8,
-2015-12-31T17:42:30.998Z,dima,KeyEvent,65535:157:4,activity-tracker,Editor,/path/to/jdk/src.zip!/java/awt/AWTEvent.java,AWTEvent::isConsumed,450,8,
+2015-12-31T17:42:30.568Z,dima,KeyEvent,401:97:85:8,activity-tracker,Editor,/path/to/jdk/src.zip!/java/awt/AWTEvent.java,AWTEvent::isConsumed,450,8,
+2015-12-31T17:42:30.998Z,dima,KeyEvent,401:65535:157:4,activity-tracker,Editor,/path/to/jdk/src.zip!/java/awt/AWTEvent.java,AWTEvent::isConsumed,450,8,
 2015-12-31T17:42:31.17Z,dima,IdeState,Active,activity-tracker,Editor,/path/to/jdk/src.zip!/java/awt/AWTEvent.java,AWTEvent::isConsumed,450,8,
 2015-12-31T17:42:32.169Z,dima,IdeState,Inactive,,,,,-1,-1,
 2015-12-31T17:42:33.168Z,dima,IdeState,Inactive,,,,,-1,-1,

--- a/src/main/activitytracker/Plugin.kt
+++ b/src/main/activitytracker/Plugin.kt
@@ -33,6 +33,8 @@ class Plugin(
 
     fun enableTrackKeyboard(value: Boolean) = updateState { it.copy(trackKeyboard = value) }
 
+    fun enableTrackKeyboardReleased(value: Boolean) = updateState { it.copy(trackKeyboardReleased = value) }
+
     fun enableTrackMouse(value: Boolean) = updateState { it.copy(trackMouse = value) }
 
     fun openTrackingLogFile(project: Project?) {
@@ -66,6 +68,7 @@ class Plugin(
         pollIdeStateMs.toLong(),
         trackIdeActions,
         trackKeyboard,
+        trackKeyboardReleased,
         trackMouse,
         mouseMoveEventsThresholdMs.toLong()
     )
@@ -77,6 +80,7 @@ class Plugin(
         val pollIdeStateMs: Int,
         val trackIdeActions: Boolean,
         val trackKeyboard: Boolean,
+        val trackKeyboardReleased: Boolean,
         val trackMouse: Boolean,
         val mouseMoveEventsThresholdMs: Int
     ) {
@@ -87,6 +91,7 @@ class Plugin(
                 setValue("$id-pollIdeStateMs", pollIdeStateMs, defaultValue.pollIdeStateMs)
                 setValue("$id-trackIdeActions", trackIdeActions, defaultValue.trackIdeActions)
                 setValue("$id-trackKeyboard", trackKeyboard, defaultValue.trackKeyboard)
+                setValue("$id-trackKeyboardReleased", trackKeyboardReleased, defaultValue.trackKeyboard)
                 setValue("$id-trackMouse", trackMouse, defaultValue.trackMouse)
                 setValue("$id-mouseMoveEventsThresholdMs", mouseMoveEventsThresholdMs, defaultValue.mouseMoveEventsThresholdMs)
             }
@@ -99,6 +104,7 @@ class Plugin(
                 pollIdeStateMs = 1000,
                 trackIdeActions = true,
                 trackKeyboard = false,
+                trackKeyboardReleased = false,
                 trackMouse = false,
                 mouseMoveEventsThresholdMs = 250
             )
@@ -111,6 +117,7 @@ class Plugin(
                         getInt("$id-pollIdeStateMs", defaultValue.pollIdeStateMs),
                         getBoolean("$id-trackIdeActions", defaultValue.trackIdeActions),
                         getBoolean("$id-trackKeyboard", defaultValue.trackKeyboard),
+                        getBoolean("$id-trackKeyboardReleased", defaultValue.trackKeyboard),
                         getBoolean("$id-trackMouse", defaultValue.trackMouse),
                         getInt("$id-mouseMoveEventsThresholdMs", defaultValue.mouseMoveEventsThresholdMs)
                     )

--- a/src/main/activitytracker/PluginUI.kt
+++ b/src/main/activitytracker/PluginUI.kt
@@ -119,6 +119,10 @@ class PluginUI(
             override fun isSelected(event: AnActionEvent) = state.trackKeyboard
             override fun setSelected(event: AnActionEvent, value: Boolean) = plugin.enableTrackKeyboard(value)
         }
+        val trackKeyboardReleased = object: CheckboxAction("Track keyboard(Released)") {
+            override fun isSelected(event: AnActionEvent) = state.trackKeyboardReleased
+            override fun setSelected(event: AnActionEvent, value: Boolean) = plugin.enableTrackKeyboardReleased(value)
+        }
         val toggleTrackMouse = object: CheckboxAction("Track mouse") {
             override fun isSelected(event: AnActionEvent) = state.trackMouse
             override fun setSelected(event: AnActionEvent, value: Boolean) = plugin.enableTrackMouse(value)
@@ -211,6 +215,7 @@ class PluginUI(
                 add(toggleTrackActions)
                 add(togglePollIdeState)
                 add(toggleTrackKeyboard)
+                add(trackKeyboardReleased)
                 add(toggleTrackMouse)
             })
             add(openHelp)

--- a/src/main/activitytracker/tracking/ActivityTracker.kt
+++ b/src/main/activitytracker/tracking/ActivityTracker.kt
@@ -74,7 +74,7 @@ class ActivityTracker(
             }
         }
         if (config.trackKeyboard || config.trackMouse) {
-            startAWTEventListener(trackerLog, trackingDisposable!!, config.trackKeyboard, config.trackMouse, config.mouseMoveEventsThresholdMs)
+            startAWTEventListener(trackerLog, trackingDisposable!!, config.trackKeyboard, config.trackKeyboardReleased, config.trackMouse, config.mouseMoveEventsThresholdMs)
         }
     }
 
@@ -112,7 +112,7 @@ class ActivityTracker(
     }
 
     private fun startAWTEventListener(
-        trackerLog: TrackerLog, parentDisposable: Disposable, trackKeyboard: Boolean,
+        trackerLog: TrackerLog, parentDisposable: Disposable, trackKeyboard: Boolean, trackKeyboardReleased: Boolean,
         trackMouse: Boolean, mouseMoveEventsThresholdMs: Long
     ) {
         var lastMouseMoveTimestamp = 0L
@@ -146,7 +146,13 @@ class ActivityTracker(
             if (trackKeyboard && awtEvent is KeyEvent && awtEvent.id == KeyEvent.KEY_PRESSED) {
                 trackerLog.append(captureIdeState(
                     TrackerEvent.Type.KeyEvent,
-                    "${awtEvent.keyChar.code}:${awtEvent.keyCode}:${awtEvent.modifiers}"
+                    "${awtEvent.id}:${awtEvent.keyChar.code}:${awtEvent.keyCode}:${awtEvent.modifiers}"
+                ))
+            }
+            if (trackKeyboard && trackKeyboardReleased && awtEvent is KeyEvent && awtEvent.id == KeyEvent.KEY_RELEASED) {
+                trackerLog.append(captureIdeState(
+                        TrackerEvent.Type.KeyEvent,
+                        "${awtEvent.id}:${awtEvent.keyChar.code}:${awtEvent.keyCode}:${awtEvent.modifiers}"
                 ))
             }
             false
@@ -284,6 +290,7 @@ class ActivityTracker(
         val pollIdeStateMs: Long,
         val trackIdeActions: Boolean,
         val trackKeyboard: Boolean,
+        val trackKeyboardReleased: Boolean,
         val trackMouse: Boolean,
         val mouseMoveEventsThresholdMs: Long
     )


### PR DESCRIPTION
The activity tracker can also log keyboard events when a key is released.

One of the ways to analyze data using recorded keylog information is keystroke dynamics. Now, using key press input events and key release events, additional characteristics such as dwell time or flight time can be measured from the recorded log.